### PR TITLE
Fix: stream schedule empty array

### DIFF
--- a/src/Service/TwitchScheduleService.php
+++ b/src/Service/TwitchScheduleService.php
@@ -19,8 +19,9 @@ class TwitchScheduleService
         $weekEnd = $weekNow->format('Y-m-d') . 'T23:59:59Z';
 
         $schedule = [];
+        $streams = $upcomingStreams['segments'] ?? [];
 
-        foreach ($upcomingStreams['segments'] as $stream) {
+        foreach ($streams as $stream) {
             $now = new DateTime('now');
 
             $eventStartTime = new DateTime($stream['start_time']);

--- a/templates/public/stream/index.html.twig
+++ b/templates/public/stream/index.html.twig
@@ -77,6 +77,9 @@
                     </div>
                 {% endfor %}
             </div>
+            {% if not schedule %}
+                <p class="text-center text-white text-xl">Aucun stream programmé pour cette semaine.</p>
+            {% endif %}
         </section>
     </main>
 {% endblock %}


### PR DESCRIPTION
This fix Closes: #16 